### PR TITLE
add validation for arguments on `create` command

### DIFF
--- a/cmd/kamimai/cmd_create.go
+++ b/cmd/kamimai/cmd_create.go
@@ -19,7 +19,7 @@ var (
 func doCreateCmd(cmd *Cmd, args ...string) error {
 	// arguments validation
 	if len(args) < 1 {
-		return errors.New("no file name specified.")
+		return errors.New("no file name specified")
 	}
 
 	// driver

--- a/cmd/kamimai/cmd_create.go
+++ b/cmd/kamimai/cmd_create.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"log"
 	"os"
 
@@ -16,6 +17,10 @@ var (
 )
 
 func doCreateCmd(cmd *Cmd, args ...string) error {
+	// arguments validation
+	if len(args) < 1 {
+		return errors.New("no file name specified.")
+	}
 
 	// driver
 	driver := core.GetDriver(config.Driver())


### PR DESCRIPTION
Dear.

I executed a `create` command with no arguments by mistakes like below.

```bash
$ POSTGRES_USER=test POSTGRES_PASSWORD=test POSTGRES_PORT=5432 POSTGRES_HOST=localhost kamimai -path=./examples/postgres/ -env=test1 create
```

then it causes runtime error like:
```bash
panic: runtime error: index out of range
```

so I fixed this to show error message like:
```bash
$ POSTGRES_USER=test POSTGRES_PASSWORD=password POSTGRES_PORT=5432 POSTGRES_HOST=localhost kamimai -path=./examples/postgres/ -env=test1 create
kamimai: no file name specified.
```

It's my pleasure if you'll care this to see my pull request. 
thanks.