### PR TITLE
fix: check timestamp in sync

### DIFF
--- a/core/migration.go
+++ b/core/migration.go
@@ -3,6 +3,8 @@ package core
 import (
 	"io/ioutil"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/eure/kamimai/internal/cast"
 )
@@ -63,6 +65,11 @@ func (m *Migration) IsValid() bool {
 		return false
 	}
 	return m.version > 0 && m.name != ""
+}
+
+func (m *Migration) IsValidTimestamp() bool {
+	_, err := time.Parse("20060102150405", strconv.FormatUint(m.version, 10))
+	return err == nil
 }
 
 //////////////////////////////

--- a/core/service.go
+++ b/core/service.go
@@ -256,10 +256,18 @@ func (s *Service) Sync() error {
 	if err := s.apply(); err != nil {
 		return err
 	}
+	if len(s.data) == 0 {
+		return nil
+	}
 
 	version := s.driver.Version()
-
+	// 一番目のマイグレーションファイルが Timestamp 形式だったらそれ以降は Timestamp 扱いにする
+	isTimeStampVer := s.data[0].IsValidTimestamp()
 	for _, mig := range s.data {
+		if isTimeStampVer != mig.IsValidTimestamp() {
+			return errors.New("invalid version format")
+		}
+
 		if count := version.Count(mig.version); count == 0 {
 			// gets current index of migrations
 			idx := s.data.index(*mig)


### PR DESCRIPTION
# これは何？

kamimai を使って DB のマイグレーションを行う場合に使います。
この kamimai のバージョン管理にタイムスタンプを使っているケースではタイムスタンプのフォーマットが間違ってるとき、後続のバージョンがおかしく問題があるので、 タイムスタンプを使ってバージョン管理してる場合は、不適切なタイムスタンプのフォーマットのときに Sync でプロセスを落とす実装を追加します。